### PR TITLE
Use int instead of double for money

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,13 @@ repositories {
 }
 
 dependencies {
-    testImplementation group: 'junit', name: 'junit', version: '4.11'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
+        exceptionFormat = 'full'
         events "passed", "skipped", "failed"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,12 @@ apply plugin: 'application'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 
-sourceCompatibility = 1.8
-ext {
-    javaMainClass = "com.thoughtworks.codepairing.SampleApp"
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
+
 repositories {
     mavenCentral()
 }
@@ -24,5 +26,6 @@ test {
     }
 }
 application {
-    mainClassName = javaMainClass
+    mainClassName = "com.thoughtworks.codepairing.SampleApp"
 }
+

--- a/src/main/java/com/thoughtworks/codepairing/SampleApp.java
+++ b/src/main/java/com/thoughtworks/codepairing/SampleApp.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 public class SampleApp {
     public static void main(String[] args) {
-        Product product1 = new Product(10.0, "DIS_10_PRODUCT1", "product 1");
-        Product product2 = new Product(20.0, "DIS_10_PRODUCT2", "product 2");
+        Product product1 = new Product(1000, "DIS_10_PRODUCT1", "product 1");
+        Product product2 = new Product(2000, "DIS_10_PRODUCT2", "product 2");
 
         List<Product> products = new ArrayList<>();
         products.add(product1);
@@ -20,7 +20,7 @@ public class SampleApp {
         Customer customer = new Customer("A Customer");
 
         ShoppingCart shoppingCart = new ShoppingCart(customer, products);
-        Product product3 = new Product(30.0, "DIS_10_PRODUCT3", "product 3");
+        Product product3 = new Product(3000, "DIS_10_PRODUCT3", "product 3");
         shoppingCart.addProduct(product3);
         System.out.println(shoppingCart.toString());
 

--- a/src/main/java/com/thoughtworks/codepairing/SampleApp.java
+++ b/src/main/java/com/thoughtworks/codepairing/SampleApp.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 public class SampleApp {
     public static void main(String[] args) {
-        Product product1 = new Product(1000, "DIS_10_PRODUCT1", "product 1");
-        Product product2 = new Product(2000, "DIS_10_PRODUCT2", "product 2");
+        Product product1 = new Product(10_00, "DIS_10_PRODUCT1", "product 1");
+        Product product2 = new Product(20_00, "DIS_10_PRODUCT2", "product 2");
 
         List<Product> products = new ArrayList<>();
         products.add(product1);
@@ -20,7 +20,7 @@ public class SampleApp {
         Customer customer = new Customer("A Customer");
 
         ShoppingCart shoppingCart = new ShoppingCart(customer, products);
-        Product product3 = new Product(3000, "DIS_10_PRODUCT3", "product 3");
+        Product product3 = new Product(30_00, "DIS_10_PRODUCT3", "product 3");
         shoppingCart.addProduct(product3);
         System.out.println(shoppingCart.toString());
 

--- a/src/main/java/com/thoughtworks/codepairing/model/Order.java
+++ b/src/main/java/com/thoughtworks/codepairing/model/Order.java
@@ -1,16 +1,16 @@
 package com.thoughtworks.codepairing.model;
 
 public class Order {
-    private double totalPrice;
+    private int totalPriceCents;
     private int loyaltyPoints;
 
-    public Order(double totalPrice, int loyaltyPointsEarned) {
-        this.totalPrice = totalPrice;
+    public Order(int totalPriceCents, int loyaltyPointsEarned) {
+        this.totalPriceCents = totalPriceCents;
         this.loyaltyPoints = loyaltyPointsEarned;
     }
 
-    public double getTotalPrice() {
-        return totalPrice;
+    public int getTotalPriceCents() {
+        return totalPriceCents;
     }
 
     public int getLoyaltyPoints() {
@@ -19,6 +19,6 @@ public class Order {
 
     @Override
     public String toString() {
-        return "Total price: " + totalPrice + "\n" + "Will receive " + loyaltyPoints + " loyalty points";
+        return "Total price: " + totalPriceCents / 100 + "." + totalPriceCents % 100 + "\n" + "Will receive " + loyaltyPoints + " loyalty points";
     }
 }

--- a/src/main/java/com/thoughtworks/codepairing/model/Product.java
+++ b/src/main/java/com/thoughtworks/codepairing/model/Product.java
@@ -1,18 +1,18 @@
 package com.thoughtworks.codepairing.model;
 
 public class Product {
-    private final double price;
+    private final int priceCents;
     private final String productCode;
     private final String name;
 
-    public Product(double price, String productCode, String name) {
-        this.price = price;
+    public Product(int priceCents, String productCode, String name) {
+        this.priceCents = priceCents;
         this.productCode = productCode;
         this.name = name;
     }
 
-    public double getPrice() {
-        return price;
+    public int getPriceCents() {
+        return priceCents;
     }
 
     public String getProductCode() {

--- a/src/main/java/com/thoughtworks/codepairing/model/ShoppingCart.java
+++ b/src/main/java/com/thoughtworks/codepairing/model/ShoppingCart.java
@@ -17,22 +17,22 @@ public class ShoppingCart {
     }
 
     public Order checkout() {
-        double totalPrice = 0;
+        int totalPrice = 0;
 
         int loyaltyPointsEarned = 0;
         for (Product product : products) {
-            double discount = 0;
+            int discountCents = 0;
             if (product.getProductCode().startsWith("DIS_10")) {
-                discount = (product.getPrice() * 0.1);
-                loyaltyPointsEarned += (product.getPrice() / 10);
+                discountCents = (int) (product.getPriceCents() * 0.1);
+                loyaltyPointsEarned += (product.getPriceCents() / 1000);
             } else if (product.getProductCode().startsWith("DIS_15")) {
-                discount = (product.getPrice() * 0.15);
-                loyaltyPointsEarned += (product.getPrice() / 15);
+                discountCents = (int) (product.getPriceCents() * 0.15);
+                loyaltyPointsEarned += (product.getPriceCents() / 1500);
             } else {
-                loyaltyPointsEarned += (product.getPrice() / 5);
+                loyaltyPointsEarned += (product.getPriceCents() / 500);
             }
 
-            totalPrice += product.getPrice() - discount;
+            totalPrice += product.getPriceCents() - discountCents;
         }
 
         return new Order(totalPrice, loyaltyPointsEarned);
@@ -40,6 +40,7 @@ public class ShoppingCart {
 
     @Override
     public String toString() {
-        return "Customer: " + customer.getName() + "\n" + "Bought:  \n" + products.stream().map(p -> "- " + p.getName()+ ", "+p.getPrice()).collect(Collectors.joining("\n"));
+        return "Customer: " + customer.getName() + "\n" + "Bought:  \n" +
+                products.stream().map(p -> "- " + p.getName()+ ", "+p.getPriceCents()/100 + "." + p.getPriceCents()%100).collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/com/thoughtworks/codepairing/model/ShoppingCart.java
+++ b/src/main/java/com/thoughtworks/codepairing/model/ShoppingCart.java
@@ -24,12 +24,12 @@ public class ShoppingCart {
             int discountCents = 0;
             if (product.getProductCode().startsWith("DIS_10")) {
                 discountCents = (int) (product.getPriceCents() * 0.1);
-                loyaltyPointsEarned += (product.getPriceCents() / 1000);
+                loyaltyPointsEarned += (product.getPriceCents() / 10_00);
             } else if (product.getProductCode().startsWith("DIS_15")) {
                 discountCents = (int) (product.getPriceCents() * 0.15);
-                loyaltyPointsEarned += (product.getPriceCents() / 1500);
+                loyaltyPointsEarned += (product.getPriceCents() / 15_00);
             } else {
-                loyaltyPointsEarned += (product.getPriceCents() / 500);
+                loyaltyPointsEarned += (product.getPriceCents() / 5_00);
             }
 
             totalPrice += product.getPriceCents() - discountCents;

--- a/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
+++ b/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShoppingCartTest {
@@ -22,7 +21,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculatePriceWithNoDiscount() {
-        List<Product> products = asList(new Product(PRICE, "", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE, "", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -31,7 +30,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculateLoyaltyPointsWithNoDiscount() {
-        List<Product> products = asList(new Product(PRICE, "", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE, "", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -40,7 +39,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculatePriceFor10PercentDiscount() {
-        List<Product> products = asList(new Product(PRICE, "DIS_10_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE, "DIS_10_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -49,7 +48,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculateLoyaltyPointsFor10PercentDiscount() {
-        List<Product> products = asList(new Product(PRICE, "DIS_10_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE, "DIS_10_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -58,7 +57,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculatePriceFor15PercentDiscount() {
-        List<Product> products = asList(new Product(PRICE, "DIS_15_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE, "DIS_15_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -67,7 +66,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculateLoyaltyPointsFor15PercentDiscount() {
-        List<Product> products = asList(new Product(PRICE, "DIS_15_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE, "DIS_15_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 

--- a/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
+++ b/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShoppingCartTest {
 
-    public static final int PRICE = 10000;
+    public static final int PRICE_CENT = 100_00;
     public static final String PRODUCT = "Product";
 
     Customer customer;
@@ -21,16 +21,16 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculatePriceWithNoDiscount() {
-        List<Product> products = List.of(new Product(PRICE, "", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE_CENT, "", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
-        assertEquals(10000, order.getTotalPriceCents());
+        assertEquals(100_00, order.getTotalPriceCents());
     }
 
     @Test
     public void shouldCalculateLoyaltyPointsWithNoDiscount() {
-        List<Product> products = List.of(new Product(PRICE, "", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE_CENT, "", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -39,16 +39,16 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculatePriceFor10PercentDiscount() {
-        List<Product> products = List.of(new Product(PRICE, "DIS_10_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE_CENT, "DIS_10_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
-        assertEquals(9000, order.getTotalPriceCents());
+        assertEquals(90_00, order.getTotalPriceCents());
     }
 
     @Test
     public void shouldCalculateLoyaltyPointsFor10PercentDiscount() {
-        List<Product> products = List.of(new Product(PRICE, "DIS_10_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE_CENT, "DIS_10_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -57,7 +57,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculatePriceFor15PercentDiscount() {
-        List<Product> products = List.of(new Product(PRICE, "DIS_15_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE_CENT, "DIS_15_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
@@ -66,7 +66,7 @@ public class ShoppingCartTest {
 
     @Test
     public void shouldCalculateLoyaltyPointsFor15PercentDiscount() {
-        List<Product> products = List.of(new Product(PRICE, "DIS_15_ABCD", PRODUCT));
+        List<Product> products = List.of(new Product(PRICE_CENT, "DIS_15_ABCD", PRODUCT));
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 

--- a/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
+++ b/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShoppingCartTest {
 
-    public static final int PRICE = 100;
+    public static final int PRICE = 10000;
     public static final String PRODUCT = "Product";
 
     Customer customer;
@@ -25,7 +25,7 @@ public class ShoppingCartTest {
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
-        assertEquals(100.0, order.getTotalPrice(), 0.0);
+        assertEquals(10000, order.getTotalPriceCents());
     }
 
     @Test
@@ -43,7 +43,7 @@ public class ShoppingCartTest {
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
-        assertEquals(90.0, order.getTotalPrice(), 0.0);
+        assertEquals(9000, order.getTotalPriceCents());
     }
 
     @Test
@@ -61,7 +61,7 @@ public class ShoppingCartTest {
         ShoppingCart cart = new ShoppingCart(customer, products);
         Order order = cart.checkout();
 
-        assertEquals(85.0, order.getTotalPrice(), 0.0);
+        assertEquals(8500, order.getTotalPriceCents(), 0.0);
     }
 
     @Test

--- a/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
+++ b/src/test/java/com/thoughtworks/codepairing/model/ShoppingCartTest.java
@@ -1,12 +1,12 @@
 package com.thoughtworks.codepairing.model;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShoppingCartTest {
 
@@ -15,8 +15,8 @@ public class ShoppingCartTest {
 
     Customer customer;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         customer = new Customer("test");
     }
 


### PR DESCRIPTION
Using double for money sets a bad example for both interviewer and candidate.

Here we use an integer amount of cents.

Pros
- the math expressions look as natural, compared to using BigDecimal that requires us to use .mutiply and .add methods

Cons
- its not a very common practice; perhaps BigDecimal is more common in Java
- the loyalty points calculation is harder to understand now